### PR TITLE
Fix shutdown of torrent2http when it is dead

### DIFF
--- a/resources/site-packages/xbmctorrent/torrent2http.py
+++ b/resources/site-packages/xbmctorrent/torrent2http.py
@@ -99,12 +99,12 @@ def start(**kwargs):
     proc.bind_address = "localhost:%d" % bind_port
     def proc_close():
         if not proc.poll():
-            xbmc.log("Trying to stop torrent2http at http://%s/shutdown" % proc.bind_address)
+            plugin.log.info("Trying to stop torrent2http at http://%s/shutdown" % proc.bind_address)
             try:
                 url_get("http://%s/shutdown" % proc.bind_address, with_immunicity=False)
             except Exception, e:
-                xbmc.log('Failed to sto torrent2http')
-                map(xbmc.log, traceback.format_exc(e))
+                plugin.log.info('Failed to sto torrent2http')
+                map(plugin.log.info, traceback.format_exc(e).split('\n'))
 
     proc.close = proc_close
     return proc


### PR DESCRIPTION
This is to fix a behavior where torrent2http crashed and instead of keep on going, xbmctorrent would break after trying to play any torrent.
