### PR TITLE
Makefile: always use tags, so it's clear on top of which release is based

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 NAME = plugin.video.xbmctorrent
 GIT = git
-GIT_VERSION = $(shell $(GIT) describe --always)
+GIT_VERSION = $(shell $(GIT) describe --tags --always)
 VERSION = $(patsubst v%,%,$(GIT_VERSION))
 ARCHS = windows_x86 darwin_x64 linux_x86 linux_x64 linux_arm android_arm
 ZIP_SUFFIX = zip


### PR DESCRIPTION
v0.6.4 is a lightway tag instead an annotated tag, so builds from git where
using 0.6.3 as prefix, when they where actually based on 0.6.4. Adding "--tags"
use the tags even if they are not annotated.
