### PR TITLE
Update library.py

### DIFF
--- a/resources/site-packages/xbmctorrent/library.py
+++ b/resources/site-packages/xbmctorrent/library.py
@@ -96,6 +96,9 @@ def library_install():
     sources_filename = xbmc.translatePath("special://userdata/sources.xml")
     root = ET.parse(sources_filename)
     video_node = root.find("./video")
+    if video_node is None:
+        plugin.notify("Please set a video directory first and try again.")
+        return
     with closing(sqlite3.connect(_get_video_db())) as conn:
         for name, entry in LIBRARY_PATHS.items():
             if not os.path.exists(xbmc.translatePath(entry["strPath"])):


### PR DESCRIPTION
if video_node is not defined an exception is thrown. 
This happens on a fresh install or when a video directory has not yet been added.
I've added a check + a message indication to prevent the exception and notify the user.
