### PR TITLE
Improvements to eztv scraper on raspberrypi

### DIFF
--- a/resources/site-packages/xbmctorrent/scrapers/eztv.py
+++ b/resources/site-packages/xbmctorrent/scrapers/eztv.py
@@ -139,16 +139,16 @@ def eztv_get_show_seasons(show_id):
 
         seasons_html = seasons_html.result()
         fanarts = []
-        if tvdb_id:
-            tvdb_show = tvdb_show.result()
-            fanarts = list([banner for banner in tvdb_show["banners"] if banner["bannertype"] == "fanart"])
-            random.shuffle(fanarts)
-
         seasons = {}
         iter_list = re.findall(r'<a .*?class="epinfo".*?>(.*?)</a.*?>', seasons_html)
         for node_episode in iter_list:
             season, episode = get_episode_data_from_name(node_episode)
             seasons.setdefault(season, {})[episode] = True
+
+        if tvdb_id:
+            tvdb_show = tvdb_show.result()
+            fanarts = list([banner for banner in tvdb_show["banners"] if banner["bannertype"] == "fanart"])
+            random.shuffle(fanarts)
 
         for i, season in enumerate(reversed(sorted(seasons.keys()))):
             item = tvdb_id and tvdb.get_season_list_item(tvdb_show, season) or {}
@@ -190,17 +190,17 @@ def eztv_get_episodes_for_season(show_id, season):
         shows = shows.result()
         items = []
         fanarts = []
-        if tvdb_id:
-            tvdb_show = tvdb_show.result()
-            fanarts = list([banner for banner in tvdb_show["banners"] if banner["bannertype"] == "fanart"])
-            random.shuffle(fanarts)
-            items = list(tvdb.build_episode_list_items(tvdb_show, int(season)))
         text_nodes = re.findall(r'<a .*?class="epinfo".*?>(.*?)</a.*?>', shows)
         href_nodes = re.findall(r'<a .*?class="magnet".*?>', shows)
         href_nodes = map(lambda x: re.findall(r'href="(.+?)"', x)[0],
                          href_nodes)
         season_nodes = izip(text_nodes, href_nodes)
         season_nodes = filter(lambda x: get_episode_data_from_name(x[0])[0] == season, season_nodes)
+        if tvdb_id:
+            tvdb_show = tvdb_show.result()
+            fanarts = list([banner for banner in tvdb_show["banners"] if banner["bannertype"] == "fanart"])
+            random.shuffle(fanarts)
+            items = list(tvdb.build_episode_list_items(tvdb_show, int(season)))
 
         for i, (node_text, node_magnet_link) in enumerate(season_nodes):
             season, episode = get_episode_data_from_name(node_text)


### PR DESCRIPTION
Hi!

These commits avoids using BeautifulSoup on the eztv scraper. The reason is that it is REALLY slow (improvements from ~45 seconds to ~10 seconds) on the raspberry pi AND the parsing we need to do is really simple.

So, instead of using BeautifulSoup this set of patches replaces them with regex. This work way faster on the pi (and, of course, perfectly fine on desktops too).

The last commit is quite simple and moves a call to ".result()" to wait for the result of something just after we need to use it. I didn't measure that change, but seems really simple.

If you have any comments, please let me know

Thanks a lot,
Rodrigo
