### PR TITLE
Use lxml, a fast XML parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ XBMC. You can increase the timeout as documented
 note that increasing the timeout won't make your network faster, you just will
 wait more time before the torrent is interrupted.
 
+#### Browsing EZTV is very slow, can I do something about it ?
+Yes! You can install python-lxml and that might make it faster if the slowdown
+is when parsing some XML files (that often is the case, specially on a raspberry
+pi or some small hardware). If you just install it, it will be used
+automatically.
+
 #### How can I use the Play-to-XBMC feature?
 First of all, install [Play-to-XBMC](https://chrome.google.com/webstore/detail/play-to-xbmc/fncjhcjfnnooidlkijollckpakkebden) from khloke.
 Then, follow the Play-to-XBMC install instructions:

--- a/resources/site-packages/xbmctorrent/library.py
+++ b/resources/site-packages/xbmctorrent/library.py
@@ -85,7 +85,10 @@ def library_install():
     import xbmc
     import xbmcgui
     from contextlib import closing
-    import xml.etree.ElementTree as ET
+    try:
+        from lxml import etree as ET
+    except ImportError:
+        import xml.etree.ElementTree as ET
 
     def _make_source_node(name, path):
         source = ET.Element("source")
@@ -122,7 +125,11 @@ def library_uninstall():
     import xbmc
     import xbmcgui
     from contextlib import closing
-    import xml.etree.ElementTree as ET
+    try:
+        from lxml import etree as ET
+    except ImportError:
+        import xml.etree.ElementTree as ET
+
     sources_filename = xbmc.translatePath("special://userdata/sources.xml")
     root = ET.parse(sources_filename)
     video_node = root.find("./video")

--- a/resources/site-packages/xbmctorrent/player.py
+++ b/resources/site-packages/xbmctorrent/player.py
@@ -89,7 +89,10 @@ class OverlayText(object):
 
     # This is so hackish it hurts.
     def _get_skin_resolution(self):
-        import xml.etree.ElementTree as ET
+        try:
+            from lxml import etree as ET
+        except ImportError:
+            import xml.etree.ElementTree as ET
         skin_path = xbmc.translatePath("special://skin/")
         tree = ET.parse(os.path.join(skin_path, "addon.xml"))
         res = tree.findall("./extension/res")[0]

--- a/resources/site-packages/xbmctorrent/scrapers/rss.py
+++ b/resources/site-packages/xbmctorrent/scrapers/rss.py
@@ -35,8 +35,11 @@ def check_imdb_id(item):
 
 @library_context
 def parse(data, content_type=None):
+    try:
+        from lxml import etree as ET
+    except ImportError:
+        import xml.etree.ElementTree as ET
     import xbmc
-    import xml.etree.ElementTree as ET
     from itertools import izip_longest
     from concurrent import futures
     from contextlib import nested, closing

--- a/resources/site-packages/xbmctorrent/tvdb.py
+++ b/resources/site-packages/xbmctorrent/tvdb.py
@@ -63,7 +63,10 @@ def get(show_id):
     from xbmctorrent.caching import shelf
     with shelf("com.thetvdb.show.%s" % show_id) as show:
         if not show:
-            import xml.etree.ElementTree as ET
+            try:
+                from lxml import etree as ET
+            except ImportError:
+                import xml.etree.ElementTree as ET
             from xbmctorrent.utils import url_get
 
             dom = ET.fromstring(url_get(show_url(show_id), headers=HEADERS, with_immunicity=False))
@@ -83,7 +86,10 @@ def search(name, complete=False):
     with shelf("com.thetvdb.search.%s" % search_hash) as show:
         if not show:
             import re
-            import xml.etree.ElementTree as ET
+            try:
+                from lxml import etree as ET
+            except ImportError:
+                import xml.etree.ElementTree as ET
             from xbmctorrent.utils import url_get
             dom = ET.fromstring(url_get("%s/api/GetSeries.php" % BASE_URL, params={
                 "seriesname": name,
@@ -98,7 +104,10 @@ def search(name, complete=False):
 
 
 def get_banners(show_id):
-    import xml.etree.ElementTree as ET
+    try:
+        from lxml import etree as ET
+    except ImportError:
+        import xml.etree.ElementTree as ET
     from xbmctorrent.utils import url_get
 
     r = url_get("%s/banners.xml" % show_base_url(show_id), headers=HEADERS, with_immunicity=False)
@@ -109,7 +118,10 @@ def get_banners(show_id):
 
 
 def get_all_meta(show_id):
-    import xml.etree.ElementTree as ET
+    try:
+        from lxml import etree as ET
+    except ImportError:
+        import xml.etree.ElementTree as ET
     from concurrent import futures
     from xbmctorrent.utils import url_get, joining
 


### PR DESCRIPTION
See the commit log for details. But basically it makes a huge difference on a raspberry-pi.

But, the question is: how to depend on lxml that are python bindings for some C library ?

Taking the approach that's being used now (including on site-packages) is not that easy, as the C library needs to be compiled for the architecture it will run. And even if we do have a C library compiled for all arch that will work, I'm not sure how to make the trick to choose the right one on each architecture.

Do you have any idea on how to handle this ?

It will be nice to have a fast XML parser
