### PR TITLE
Add missing import

### DIFF
--- a/resources/site-packages/xbmctorrent/torrent2http.py
+++ b/resources/site-packages/xbmctorrent/torrent2http.py
@@ -2,6 +2,7 @@ import os
 import sys
 import stat
 import subprocess
+import traceback
 import xbmcaddon
 from xbmctorrent.common import RESOURCES_PATH
 from xbmctorrent.platform import PLATFORM


### PR DESCRIPTION
Where plugin is trying to log an exception, it uses traceback which is not imported